### PR TITLE
Allow for per-project tagged charges.

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -41,7 +41,8 @@ class ChargesController < DonationsController
 
     # HACK TODO: fix the dollars / cents thing
     @charge = @donor.charges.new({
-      amount: charge_params[:amount].to_i * 100
+      amount: charge_params[:amount].to_i * 100,
+      tag: charge_params[:tag]
     })
 
     if @charge.save

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -7,6 +7,10 @@ class DonationsController < ApplicationController
     @title = "Thanks!"
   end
 
+  def project
+    @name = params[:project]
+  end
+
   private
 
   def donor_params
@@ -14,7 +18,7 @@ class DonationsController < ApplicationController
   end
 
   def charge_params
-    params.require(:charge).permit(:amount, :recurring)
+    params.require(:charge).permit(:amount, :recurring, :tag)
   end
 
   def plan_params

--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -17,7 +17,7 @@ module DonationsHelper
   ]
 
   def top_ten_charges
-    Charge.order('amount DESC').limit(10)
+    Charge.where(tag: nil).order('amount DESC').limit(10)
   end
 
   def donation_goal

--- a/app/views/donations/_credit_card.html.erb
+++ b/app/views/donations/_credit_card.html.erb
@@ -17,11 +17,14 @@
     <input type="text" class="form-control cc-exp" data-stripe="exp" inputmode="numeric" placeholder="MM / YY">
     <input type="text" class="form-control cc-cvc" size="20" data-stripe="cvc" inputmode="numeric" placeholder="CVC" />
   </div>
-  <div class="checkbox">
-    <label>
-      <input type="checkbox" name="charge[recurring]"> Recurring donation on a monthly basis
-    </label>
-  </div>
+
+  <% if allow_recurring %>
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" name="charge[recurring]"> Recurring donation on a monthly basis
+      </label>
+    </div>
+  <% end %>
 
   <!-- Donor information -->
   <div class="form-group">
@@ -43,6 +46,8 @@
       <input type="checkbox" name="donor[anonymous]"> I wish to be anonymous
     </label>
   </div>
+
+  <input type="hidden" value="<%= params[:project] %>" name="charge[tag]">
 
   <div class="form-group">
     <%= button_tag "Donate", {class: "btn btn-primary"} %>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -11,7 +11,7 @@
 
   <div class="tab-content">
     <div role="tabpanel" class="tab-pane active" id="credit-card">
-      <%= render "credit_card" %>
+      <%= render "credit_card", allow_recurring: true %>
     </div>
     <div role="tabpanel" class="tab-pane" id="bitcoin">
       <%= render "bitcoin" %>

--- a/app/views/donations/_project_donation_form.html.erb
+++ b/app/views/donations/_project_donation_form.html.erb
@@ -1,0 +1,9 @@
+<h3>Donate to project <%= @name.titleize %> </h3>
+
+<%= render "notices" %>
+
+<div role="tabpanel" class="donations">
+  <div class="tab-content">
+    <%= render "credit_card", allow_recurring: false %>
+  </div>
+</div>

--- a/app/views/donations/project.html.erb
+++ b/app/views/donations/project.html.erb
@@ -1,0 +1,12 @@
+<div class="row">
+  <div class="col-md-8 col-md-offset-2 donation-header">
+    <a href="http://noisebridge.net">
+      <%= image_tag('noisebridge_logo.jpg', class: 'center noisebridge_logo') %>
+    </a>
+    <h3>Noisebridge: a hacker spaceship needs your help!</h3>
+  </div>
+
+  <div class="col-md-4 col-md-offset-4 donation-form">
+    <%= render "project_donation_form", project: true %>
+  </div>
+</div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,6 +21,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  password: noisebridge
   database: noisebridge_donate_test
 
 production:

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,4 +36,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Fixes deprecation notice about default in upcoming Rails 5
+  config.active_support.test_order = :random
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'donations#index'
 
   get '/thanks', to: 'donations#thanks'
+  get '/projects/:project', to: 'donations#project'
 
   scope :donations do
     resource :subscriptions, only: [:create]

--- a/db/migrate/20160122044601_add_tag_to_charges.rb
+++ b/db/migrate/20160122044601_add_tag_to_charges.rb
@@ -1,0 +1,5 @@
+class AddTagToCharges < ActiveRecord::Migration
+  def change
+    add_column(:charges, :tag, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,21 +11,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150523043432) do
+ActiveRecord::Schema.define(version: 20160122044601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "charges", force: true do |t|
+  create_table "charges", force: :cascade do |t|
     t.integer  "donor_id",         null: false
     t.integer  "amount",           null: false
     t.string   "stripe_charge_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "subscription_id"
+    t.string   "tag"
   end
 
-  create_table "donors", force: true do |t|
+  create_table "donors", force: :cascade do |t|
     t.string   "email",                                          null: false
     t.string   "stripe_customer_id",                             null: false
     t.datetime "created_at"
@@ -34,7 +35,7 @@ ActiveRecord::Schema.define(version: 20150523043432) do
     t.boolean  "anonymous",                      default: false
   end
 
-  create_table "stripe_plans", force: true do |t|
+  create_table "stripe_plans", force: :cascade do |t|
     t.string   "stripe_id"
     t.string   "name",       null: false
     t.integer  "amount",     null: false
@@ -44,7 +45,7 @@ ActiveRecord::Schema.define(version: 20150523043432) do
 
   add_index "stripe_plans", ["stripe_id"], name: "index_stripe_plans_on_stripe_id", unique: true, using: :btree
 
-  create_table "stripe_subscriptions", force: true do |t|
+  create_table "stripe_subscriptions", force: :cascade do |t|
     t.string   "stripe_status"
     t.datetime "cancellation_requested_at"
     t.datetime "cancelled_at"

--- a/spec/controllers/charges_controller_spec.rb
+++ b/spec/controllers/charges_controller_spec.rb
@@ -50,6 +50,15 @@ describe ChargesController, type: :controller do
       expect(assigns(:donor)).to be_anonymous
       expect(assigns(:charge)).to be_persisted
     end
+
+    it "allows for tagged charges" do
+      post :create,
+        donor: { email: email, stripe_token: stripe_token, anonymous: true },
+        charge: {amount: 10, tag: "bottle-light"},
+        format: :json
+      expect(assigns(:donor)).to be_anonymous
+      expect(assigns(:charge).tag).to eq("bottle-light")
+    end
   end
 
   context 'creating Subscriptions' do


### PR DESCRIPTION
Project pages are /project/:name and will display only the one-time charge form,
with a header stating that the funds will be earmarked for the specified
project.

TODO: Dashboard to show per-project balances
TODO: Admin interface to monitor projects / charges
TODO: Admin logins to allow management of Subscriptions
 
Fixes #41 