### PR TITLE
Remove paypal donation options

### DIFF
--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -59,10 +59,5 @@ module DonationsHelper
   def standard_donation_amounts
     STANDARD_DONATION_AMOUNTS
   end
-
-  def paypal_donation_link(amount)
-    link_to "#{number_to_currency(amount, precision: 0)} / month",
-      "https://www.paypal.com/subscriptions/business=treasurer@noisebridge.net&item_name=Noisebridge%20Monthly%20Donation%20%28Affiliate%20Member%29&cy_code=USD&a3=#{amount}&p3=1&t3=M&src=1", target: "_blank"
-  end
 end
 

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -6,7 +6,6 @@
   <ul class="nav nav-tabs" role="tablist">
     <li role="presentation" class="active"><a href="#credit-card" aria-controls="credit-card" role="tab" data-toggle="tab">Credit Card</a></li>
     <li role="presentation"><a href="#bitcoin" aria-controls="bitcoin" role="tab" data-toggle="tab">Bitcoin</a></li>
-    <li role="presentation"><a href="#paypal" aria-controls="paypal" role="tab" data-toggle="tab">PayPal</a></li>
   </ul>
 
   <div class="tab-content">
@@ -16,8 +15,8 @@
     <div role="tabpanel" class="tab-pane" id="bitcoin">
       <%= render "bitcoin" %>
     </div>
+  </div>
     <div role="tabpanel" class="tab-pane" id="paypal">
       <%= render "paypal" %>
     </div>
-  </div>
 </div>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "notices" %>
 
-<div role="tabpanel" class="donations">
+<div role="tabanel" class="donations">
   <ul class="nav nav-tabs" role="tablist">
     <li role="presentation" class="active"><a href="#credit-card" aria-controls="credit-card" role="tab" data-toggle="tab">Credit Card</a></li>
     <li role="presentation"><a href="#bitcoin" aria-controls="bitcoin" role="tab" data-toggle="tab">Bitcoin</a></li>
@@ -16,7 +16,4 @@
       <%= render "bitcoin" %>
     </div>
   </div>
-    <div role="tabpanel" class="tab-pane" id="paypal">
-      <%= render "paypal" %>
-    </div>
 </div>

--- a/app/views/donations/_paypal.html.erb
+++ b/app/views/donations/_paypal.html.erb
@@ -1,9 +1,0 @@
-<div class="paypal">
-  <p>Click any of the links below to set up a recurring donation with PayPal</p>
-
-  <ul>
-    <% standard_donation_amounts.each do |amount| %>
-      <li><%= paypal_donation_link(amount) %></li>
-    <% end %>
-  </ul>
-</div>


### PR DESCRIPTION
In the long run we'd like to move people completely off donations using
paypal. We should stop promoting it and encouraging folks to create new
subscriptions using it.