### PR TITLE
Email receipts for all charge.succeeded events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,23 @@
 source 'https://rubygems.org'
 
-gem 'stripe', :source => 'https://code.stripe.com/'
+gem 'autoprefixer-rails'
+gem 'dotenv-rails'
+gem 'jquery-rails'
 gem 'pg'
-
 gem 'rails', '5.0.0.beta3'
 gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
-gem 'jquery-rails'
-gem 'dotenv-rails'
-gem 'autoprefixer-rails'
-gem 'skylight'
-gem 'sentry-raven'
 gem 'secure_headers'
+gem 'sentry-raven'
+gem 'sentry-raven'
+gem 'sidekiq'
+gem 'skylight'
+gem 'stripe', :source => 'https://code.stripe.com/'
+gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do
-  gem 'spring'
-  gem 'pry'
   gem 'foreman'
+  gem 'pry'
+  gem 'spring'
 end
 
 group :development do
@@ -27,6 +28,6 @@ group :test do
   gem 'rails-controller-testing'
   gem 'factory_girl_rails'
   gem 'guard-rspec', require: false
-  gem 'shoulda-matchers'
   gem 'rspec-rails', '~> 3.1'
+  gem 'shoulda-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     builder (3.2.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.1)
+    connection_pool (2.2.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     domain_name (0.5.20160310)
@@ -156,6 +157,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redis (3.2.2)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -194,6 +196,10 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    sidekiq (4.1.1)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      redis (~> 3.2, >= 3.2.1)
     skylight (0.10.3)
       activesupport (>= 3.0.0)
     slop (3.6.0)
@@ -247,6 +253,7 @@ DEPENDENCIES
   secure_headers
   sentry-raven
   shoulda-matchers
+  sidekiq
   skylight
   spring
   stripe!

--- a/app/controllers/api/stripe_events_controller.rb
+++ b/app/controllers/api/stripe_events_controller.rb
@@ -1,0 +1,28 @@
+class Api::StripeEventsController < ApplicationController
+  skip_before_filter :verify_authenticity_token
+
+  def create
+    # Parse incoming webhook. Retrieve the specified event from Stripe to
+    # prevent posting of invalid & unauthorized data, record event in our local
+    # SQL table and finally process it
+    StripeEvent.record_and_process(stripe_event)
+    head :created
+  rescue JSON::ParserError
+    return head 400
+  rescue StandardError => exc
+    Raven.capture_exception(exc, { affects: :stripe })
+    head 500
+  end
+
+  private def json
+    @json ||= JSON.parse(request.body.read)
+  end
+
+  private def stripe_event_id
+    json['id']
+  end
+
+  private def stripe_event
+    @stripe_event ||= Stripe::Event.retrieve(stripe_event_id)
+  end
+end

--- a/app/mailers/receipt_mailer.rb
+++ b/app/mailers/receipt_mailer.rb
@@ -1,0 +1,12 @@
+module ReceiptMailer < ActionMailer
+
+  def notify_of_donation(email, amount)
+    @amount = amount
+    @donor = Donor.find_by(email: email)
+    mail(
+      from: 'Noisebridge <no-reply@donate.noisebridge.net>',
+      to: email,
+      subject: "We have received your recurring donation"
+    )
+  end
+end

--- a/app/models/stripe_event.rb
+++ b/app/models/stripe_event.rb
@@ -15,6 +15,7 @@ class StripeEvent < ApplicationRecord
     if should_email_receipt?
       queue_email_receipt_mail
     end
+    mark_processed!
   end
 
   def type

--- a/app/models/stripe_event.rb
+++ b/app/models/stripe_event.rb
@@ -8,7 +8,7 @@ class StripeEvent < ApplicationRecord
     create!(
       body: stripe_event.as_json,
       stripe_id: stripe_event.id
-    )
+    ).process
   end
 
   def process

--- a/app/models/stripe_event.rb
+++ b/app/models/stripe_event.rb
@@ -1,0 +1,8 @@
+class StripeEvent < ApplicationRecord
+
+  validates_presence_of :stripe_id, :body
+
+  def mark_processed!
+    update_attributes!(processed_at: Time.zone.now)
+  end
+end

--- a/app/models/stripe_event.rb
+++ b/app/models/stripe_event.rb
@@ -1,8 +1,45 @@
 class StripeEvent < ApplicationRecord
 
+  CHARGE_SUCCEEDED = "charge.succeeded".freeze
+
   validates_presence_of :stripe_id, :body
+
+  def self.record_and_process(stripe_event)
+    create!(
+      body: stripe_event.as_json,
+      stripe_id: stripe_event.id
+    )
+  end
+
+  def process
+    if should_email_receipt?
+      queue_email_receipt_mail
+    end
+  end
+
+  def type
+    body['type']
+  end
+
+  def remote_created_at
+    Time.at(body['created'])
+  end
 
   def mark_processed!
     update_attributes!(processed_at: Time.zone.now)
+  end
+
+  private def should_email_receipt?
+    type == CHARGE_SUCCEEDED
+  end
+
+  private def customer_id
+    body['data']['object']['customer']
+  end
+
+  private def queue_email_receipt_mail
+    email = Donor.find_by(stripe_customer_id: customer_id).email
+    amount = body['data']['object']['amount']
+    ReceiptEmailWorker.perform_async(email: email, amount: amount)
   end
 end

--- a/app/views/receipt_mailer/notify_of_donation.text.erb
+++ b/app/views/receipt_mailer/notify_of_donation.text.erb
@@ -1,0 +1,17 @@
+Dear <%= @donor.first_name || "there" %>,
+
+Your recurring donation of <%= number_to_currency(@amount / 100) %> was
+successfully received today. Your ongoing support is immensely appreciated by
+the Noisebridge community and helps us continue our mission of providing
+open-access technical education to all.
+
+If you need any assistance with donations please contact us at
+treasurer@noisebridge.net.
+
+Thanks again for all your support!
+
+Noisebridge.
+
+P.S Noisebridge is a U.S 501(c)(3) non-profit organisation and our federal tax
+ID is 26-3507741. Your donation is tax deductible as allowed by law, less any
+premiums of significant value received.

--- a/app/workers/receipt_email_worker.rb
+++ b/app/workers/receipt_email_worker.rb
@@ -1,0 +1,7 @@
+class ReceiptEmailWorker
+  include Sidekiq::Worker
+
+  def perform(email, amount)
+    ReceiptMailer.notify_of_donation(email, amount).deliver
+  end
+end

--- a/app/workers/receipt_email_worker.rb
+++ b/app/workers/receipt_email_worker.rb
@@ -1,7 +1,7 @@
 class ReceiptEmailWorker
   include Sidekiq::Worker
 
-  def perform(email, amount)
+  def perform(email:, amount:)
     ReceiptMailer.notify_of_donation(email, amount).deliver
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,8 @@ Rails.application.routes.draw do
     resource :subscriptions, only: [:create]
     resource :charges, only: [:create]
   end
+
+  namespace :api do
+    resource :stripe_events, only: [:create]
+  end
 end

--- a/db/migrate/20160407041016_create_stripe_events.rb
+++ b/db/migrate/20160407041016_create_stripe_events.rb
@@ -1,0 +1,10 @@
+class CreateStripeEvents < ActiveRecord::Migration[5.0]
+  def change
+    create_table :stripe_events do |t|
+      t.string :stripe_id, null: false
+      t.json :body
+      t.datetime :processed_at
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160407055048_add_unique_index_to_stripe_event_stripe_id.rb
+++ b/db/migrate/20160407055048_add_unique_index_to_stripe_event_stripe_id.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToStripeEventStripeId < ActiveRecord::Migration[5.0]
+  def change
+    add_index(:stripe_events, :stripe_id, unique: true, using: :btree)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160407041016) do
+ActiveRecord::Schema.define(version: 20160407055048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,8 @@ ActiveRecord::Schema.define(version: 20160407041016) do
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
   end
+
+  add_index "stripe_events", ["stripe_id"], name: "index_stripe_events_on_stripe_id", unique: true, using: :btree
 
   create_table "stripe_plans", force: :cascade do |t|
     t.string   "stripe_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160122044601) do
+ActiveRecord::Schema.define(version: 20160407041016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,14 @@ ActiveRecord::Schema.define(version: 20160122044601) do
     t.datetime "updated_at"
     t.string   "name",               limit: 120
     t.boolean  "anonymous",                      default: false
+  end
+
+  create_table "stripe_events", force: :cascade do |t|
+    t.string   "stripe_id",    null: false
+    t.json     "body"
+    t.datetime "processed_at"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
 
   create_table "stripe_plans", force: :cascade do |t|

--- a/spec/controllers/api/stripe_events_controller_spec.rb
+++ b/spec/controllers/api/stripe_events_controller_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Api::StripeEventsController do
+  let(:event) { create(:stripe_event) }
+
+  context "POST #create" do
+    it "retrieves the Stripe::Event and persists it" do
+      expect(Stripe::Event).to receive(:retrieve).
+                                with(event.stripe_id).
+                                and_return(true)
+      expect(StripeEvent).to receive(:record_and_process)
+
+      post :create, body: { id: event.stripe_id }.to_json, format: :json
+
+      expect(response).to be_success
+    end
+
+    context "with bad JSON" do
+      it "returns 500" do
+        post :create, body: "this is a thing", format: :json
+        expect(response.code).to eq("400")
+      end
+    end
+  end
+end

--- a/spec/factories/stripe_event.rb
+++ b/spec/factories/stripe_event.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :stripe_event do
+    sequence(:stripe_id) { |n|  "stripe-event-#{n}" }
+    body JSON.generate(key: "value")
+  end
+end

--- a/spec/models/stripe_event_spec.rb
+++ b/spec/models/stripe_event_spec.rb
@@ -5,6 +5,17 @@ RSpec.describe StripeEvent do
   it { is_expected.to validate_presence_of(:stripe_id) }
   it { is_expected.to validate_presence_of(:body) }
 
+  context ".record_and_process" do
+    let(:event) { create(:stripe_event) }
+
+    it "creates an event and processes it" do
+      expect(subject.class).to receive(:create!).and_return(event)
+      expect(event).to receive(:process).and_return(true)
+
+      subject.class.record_and_process(event)
+    end
+  end
+
   context "#mark_processed!" do
     let(:event) { StripeEvent.create!(stripe_id: "foo", body: {key: "value"}) }
 

--- a/spec/models/stripe_event_spec.rb
+++ b/spec/models/stripe_event_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe StripeEvent do
+
+  it { is_expected.to validate_presence_of(:stripe_id) }
+  it { is_expected.to validate_presence_of(:body) }
+
+  context "#mark_processed!" do
+    let(:event) { StripeEvent.create!(stripe_id: "foo", body: {key: "value"}) }
+
+    it "sets the processed_at timestamp" do
+      expect {event.mark_processed! }.to change { event.reload.processed_at }
+    end
+  end
+
+end

--- a/spec/models/stripe_event_spec.rb
+++ b/spec/models/stripe_event_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe StripeEvent do
     context "with a charge.succeeded" do
       let(:donor) { create(:donor) }
       let(:event) {
-        subject.class.new(
+        build(:stripe_event,
           body: {
             type: "charge.succeeded",
             data: {
@@ -70,6 +70,13 @@ RSpec.describe StripeEvent do
           with(email: donor.email, amount: 100_00).
           and_return(true)
         expect(event.process).to eq(true)
+      end
+
+      it "marks as processed!" do
+        event = create(:stripe_event)
+        expect {
+          event.process
+        }.to change { event.reload.processed_at }
       end
     end
   end


### PR DESCRIPTION
Introduces a new `Api::StripeEventsController` which is used to respond to incoming Stripe webhooks. To prevent any forgery or spoofing of events we retrieve each event afresh from the Stripe API for processing.

This PR introduces a new `StripeEvent` model which is persisted is PostgreSQL. It's a simple event AR model which persists the entire JSON body of the `Stripe::Event` record. 

TODO: 
 - [x] Prevent replay attacks with individual events by using  `find_or_create`
 - [x] Prevent accidental double-processing of events by noop'ing in `#process`