### PR TITLE
Add notice to README about encrypted .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ bundle install
 ### Running with secrets
 The secrets for the development environment are kept encrypted in the `.env` file. `git-crypt` will unlock them.
 
+**NB: You must be aded to the list of secrets users before you can decrypt the .env file**
+
+If you don't have access to the decrypted `.env` file locally you'll likely see
+an error like so when you attempt to attempt to run the Rails console or server
+locally. 
+```
+/home/patrickod/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/dotenv-2.1.1/lib/dotenv/parser.rb:44:in `split': invalid byte sequence in UTF-8 (ArgumentError)
+```
+
+This is because `dotenv` is attempting to parse a non-ASCII file (the
+encrypted blob). Simply `rm .env` to remove the local copy. If you want to run
+with local development Stripe API credentials for the Noisebridge account ask
+@patrickod to add you to the list of PGP keys that can decrypt the `.env` file.
+
+
+#### 
+
 To run the rails server locally with the secrets loaded use `foreman start web`
 
 ### Running without secrets


### PR DESCRIPTION
Running with the .env file encrypted causes dotenv to throw exceptions
as it attempts to parse what it expects to be an ASCII file, but instead
is a blob of encrypted data.