### PR TITLE
clean up numerous deprecations and warnings

### DIFF
--- a/app/controllers/api/stripe_events_controller.rb
+++ b/app/controllers/api/stripe_events_controller.rb
@@ -1,5 +1,5 @@
 class Api::StripeEventsController < ApplicationController
-  skip_before_filter :verify_authenticity_token
+  skip_before_action :verify_authenticity_token
 
   def create
     # Parse incoming webhook. Retrieve the specified event from Stripe to

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -12,7 +12,6 @@ SecureHeaders::Configuration.default do |config|
 
     # directive values: these values will directly translate into source directives
     default_src: %w(https: 'self'),
-    frame_src: %w('self' js.stripe.com),
     connect_src: %w(wws:),
     font_src: %w('self' fonts.gstatic.com fonts.googleapis.com),
     img_src: %w('self'),
@@ -21,7 +20,7 @@ SecureHeaders::Configuration.default do |config|
     script_src: %w('self' js.stripe.com),
     style_src: %w('self' fonts.googleapis.com),
     base_uri: %w('self'),
-    child_src: %w('self'),
+    child_src: %w('self' js.stripe.com),
     form_action: %w('self' github.com),
     frame_ancestors: %w('none'),
     plugin_types: %w(application/x-shockwave-flash),

--- a/spec/controllers/charges_controller_spec.rb
+++ b/spec/controllers/charges_controller_spec.rb
@@ -44,13 +44,11 @@ describe ChargesController, type: :controller do
     end
 
     it 'allows for anonymous donations' do
-      expect(Donor).to receive(:new) do |params| 
-        expect(params.to_h).to eq({
-          email: email,
-          stripe_token: stripe_token,
-          anonymous: "true"
-        })
-      end.and_call_original
+      expect(Donor).to receive(:new).with({
+        email: email,
+        stripe_token: stripe_token,
+        anonymous: "true"
+      }).and_call_original
 
       post :create,
         params: {
@@ -114,4 +112,3 @@ describe ChargesController, type: :controller do
     end
   end
 end
-


### PR DESCRIPTION
Fix child_src frame_src deprecation warning for secureheaders.
Fix rspec warning about stub on new w/ and_call_original
Fix deprecation notice for skip_before_filter