### PR TITLE
Mount the sidekiq web interface at /sidekiq

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,10 @@ Style/IndentationWidth:
   Exclude:
     - 'app/controllers/donations_controller.rb'
 
+Style/MultilineIfModifier:
+  Exclude:
+    - "config/routes.rb"
+
 Metrics/MethodLength:
   Max: 20
 
@@ -55,6 +59,8 @@ Metrics/AbcSize:
 
 Metrics/LineLength:
   Max: 127
+  Exclude:
+    - "config/routes.rb"
 
 Metrics/BlockLength:
   Exclude:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,10 @@
+require 'sidekiq/web'
+
+Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+  ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(Rails.application.secrets.sidekiq_web_username)) &
+    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(Rails.application.secrets.sidekiq_web_password))
+end if Rails.env.production?
+
 Rails.application.routes.draw do
   root 'donations#index'
 
@@ -14,4 +21,6 @@ Rails.application.routes.draw do
     resource :stripe_events, only: [:create]
     resource :paypal_notifications, only: [:create]
   end
+
+  mount Sidekiq::Web, at: "/sidekiq"
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -27,4 +27,6 @@ production: &production
   <<: *base
   secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
   postgresql_password: <%= ENV['POSTGRESQL_PASSWORD'] %>
+  sidekiq_web_username: <%= ENV['SIDEKIQ_WEB_USERNAME'] %>
+  sidekiq_web_password: <%= ENV['SIDEKIQ_WEB_PASSWORD'] %>
 


### PR DESCRIPTION
Protect it with HTTP basic authentication. Secrets have been configured in the
productiov.env on ratchet ahead of deployment.