### PR TITLE
Change example name from Edward Snowden

### DIFF
--- a/app/views/donations/_credit_card.html.erb
+++ b/app/views/donations/_credit_card.html.erb
@@ -31,14 +31,14 @@
     <label for="donor[email]">
       Email
     </label>
-    <input type="email" class="form-control" name="donor[email]" placeholder="edward.snowden@eff.org" %>
+    <input type="email" class="form-control" name="donor[email]" placeholder="dade.murphy@eff.org" %>
   </div>
 
   <div class="form-group">
     <label for="donor[name]">
       Name
     </label>
-    <input type="text" class="form-control" name="donor[name]" placeholder="Edward Snowden" %>
+    <input type="text" class="form-control" name="donor[name]" placeholder="Dade Murphy" %>
   </div>
 
   <div class="checkbox">

--- a/app/views/donations/_recurring_donation_form.html.erb
+++ b/app/views/donations/_recurring_donation_form.html.erb
@@ -23,14 +23,14 @@
     <label for="donor[email]">
       Email
     </label>
-    <input type="email" class="form-control" name="donor[email]" placeholder="edward.snowden@eff.org" %>
+    <input type="email" class="form-control" name="donor[email]" placeholder="dade.murphy@eff.org" %>
   </div>
 
   <div class="form-group">
     <label for="donor[name]">
       Name
     </label>
-    <input type="text" class="form-control" name="donor[name]" placeholder="Edward Snowden" %>
+    <input type="text" class="form-control" name="donor[name]" placeholder="Dade Murphy" %>
   </div>
 
   <div class="checkbox">


### PR DESCRIPTION
This seems like a small thing, but as much as I like this the way it is,
Snowden is _so_ polarizing, I'd rather not have that debate right as
someone is about to donate to us. Intelligent, caring, thoughtful people
can have wildly opposing opinions on this subject, and having his name
there seems like unnecessarily politicizing the donation process, which
can only hurt it.

Instead, I added "Hackers" reference.