### PR TITLE
Fix footer/header links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
   end
 
   def github_link
-    link_to("donate.noisebridge.net", GITHUB_URL)
+    link_to("donate.noisebridge.net", root_url)
   end
 
   def bitcoin_link

--- a/app/views/donations/index.html.erb
+++ b/app/views/donations/index.html.erb
@@ -1,8 +1,8 @@
 <div class="row">
   <div class="col-md-8 col-md-offset-2 donation-header">
-    <a href="http://noisebridge.net">
+    <%= link_to root_url do %>
       <%= image_tag('noisebridge_logo.jpg', class: 'center noisebridge_logo') %>
-    </a>
+    <% end %>
     <h3>Noisebridge: a hackerspace needs your help!</h3>
   </div>
   <div class="col-md-10 col-md-offset-1">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,8 +1,8 @@
 <div class="row">
   <div class="col-md-8 col-md-offset-2 donation-header">
-    <a href="http://noisebridge.net">
+    <%= link_to root_url do %>
       <%= image_tag('noisebridge_logo.jpg', class: 'center noisebridge_logo') %>
-    </a>
+    <% end %>
     <h3>Noisebridge: a hackerspace needs your help!</h3>
   </div>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,8 +1,8 @@
 <div class="row">
   <div class="col-md-8 col-md-offset-2 donation-header">
-    <a href="http://noisebridge.net">
+    <%= link_to root_url do %>
       <%= image_tag('noisebridge_logo.jpg', class: 'center noisebridge_logo') %>
-    </a>
+    <% end %>
     <h3>Noisebridge: a hackerspace needs your help!</h3>
   </div>
 </div>


### PR DESCRIPTION
Fixes #89 and #90 by changing links to point back to the homepage rather than either noisebridge.net or Github.