### PR TITLE
Highlight recurring donation option

### DIFF
--- a/app/views/donations/_credit_card.html.erb
+++ b/app/views/donations/_credit_card.html.erb
@@ -19,7 +19,7 @@
   </div>
 
   <% if allow_recurring %>
-    <div class="checkbox">
+    <div class="alert alert-info checkbox">
       <label>
         <input type="checkbox" name="charge[recurring]"> Recurring donation on a monthly basis
       </label>


### PR DESCRIPTION
Make the recurring option more visible, with the thought that more folks may opt to use it. 

Could also be worth linking to donation page from NB home with `?amount=40` or `?amount=80` to prod the default amount higher. 

These are kind of general NPO fundraising optimizations, https://npengage.com/nonprofit-fundraising/the-top-10-most-effective-donation-form-optimizations-you-can-make/