### PR TITLE
Update donor details on successive charges

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -19,10 +19,16 @@ class DonationsController < ApplicationController
 
   private def find_or_create_donor
     @donor = if Donor.exists?(email: donor_params[:email])
-      Donor.find_by(email: donor_params[:email])
+      find_and_update_donor
     else
       create_donor
     end
+  end
+
+  private def find_and_update_donor
+    donor = Donor.find_by(email: donor_params[:email])
+    donor.update_attributes!(donor_params)
+    donor
   end
 
   private def create_donor

--- a/spec/controllers/charges_controller_spec.rb
+++ b/spec/controllers/charges_controller_spec.rb
@@ -23,6 +23,26 @@ describe ChargesController, type: :controller do
         .and_return(stripe_charge)
     end
 
+    context 'updating the Donor details for existing donors' do
+      it 'updates the Donor details for successive charges' do
+        donor = Donor.create!(email: email, stripe_token: stripe_token, name: "Previous")
+        post :create,
+             params: {
+               donor: {
+                 email: email,
+                 stripe_token: stripe_token,
+                 name: "Currently"
+               },
+               charge: {
+                 amount: 10
+               }
+             },
+             format: :json
+        expect(assigns(:charge)).to be_persisted
+        expect(donor.reload.name).to eq("Currently")
+      end
+    end
+
     it 'creates a Donor and Charge' do
       expect(Donor).to receive(:new).with(
         email: email,


### PR DESCRIPTION
Should someone donate again and use the same email then we'll update their
details with whatever anonymity and name they pass.