### PR TITLE
Move logo and heading to be above copy

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,16 +38,22 @@ body {
 .donation-header {
   font-family: 'Bitter', serif;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
 
   align-items: center;
   justify-content: space-around;
+    
+  .header-title {
+    display: flex;
+    align-items: baseline;
+  }
 
   h3 {
     font-weight: bold;
   }
 
   .noisebridge_logo {
+    margin: 10px;
     width: 120px;
   }
 }
@@ -78,6 +84,10 @@ body {
   .donation-header {
     flex-direction: column;
     text-align: center;
+      
+    .header-title {
+      display: block;
+    }
 
     .noisebridge_logo {
       width: 80px;


### PR DESCRIPTION
This the CSS that goes along with the changes in `fix-large-viewport-layout` branch. This moves the 4 paragraphs of copy below the logo and h3, instead of in the same row as the logo and h3 in 4 separate, narrow columns.